### PR TITLE
Update version number for release.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ routesGenerator := InjectedRoutesGenerator
 
 // Docker Configuration
 packageName in Docker := "pathfinder-webserver"
-version in Docker := "0.1.8"
+version in Docker := "0.1.9"
 maintainer := "Pathfinder Team"
 dockerRepository := Some("beta.gcr.io/phonic-aquifer-105721")
 dockerExposedPorts in Docker := Seq(9000, 9443)


### PR DESCRIPTION
Release of v0.1.8 failed because I included outdated evolutions.
